### PR TITLE
Fix inconsistency in read/write format of OperationId in Redis Scheduler Store

### DIFF
--- a/nativelink-scheduler/src/store_awaited_action_db.rs
+++ b/nativelink-scheduler/src/store_awaited_action_db.rs
@@ -264,7 +264,8 @@ impl SchedulerStoreKeyProvider for ClientIdToOperationId<'_> {
 impl SchedulerStoreDecodeTo for ClientIdToOperationId<'_> {
     type DecodeOutput = OperationId;
     fn decode(_version: u64, data: Bytes) -> Result<Self::DecodeOutput, Error> {
-        OperationId::try_from(data).err_tip(|| "In ClientIdToOperationId::decode")
+        serde_json::from_slice(&data)
+            .map_err(|e| make_input_err!("In ClientIdToOperationId::decode - {e:?}"))
     }
 }
 

--- a/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
+++ b/nativelink-scheduler/tests/redis_store_awaited_action_db_test.rs
@@ -35,7 +35,7 @@ use nativelink_scheduler::awaited_action_db::{
 use nativelink_scheduler::store_awaited_action_db::StoreAwaitedActionDb;
 use nativelink_store::redis_store::{RedisStore, RedisSubscriptionManager};
 use nativelink_util::action_messages::{
-    ActionInfo, ActionStage, ActionUniqueKey, ActionUniqueQualifier,
+    ActionInfo, ActionStage, ActionUniqueKey, ActionUniqueQualifier, OperationId,
 };
 use nativelink_util::common::DigestInfo;
 use nativelink_util::digest_hasher::DigestHasherFunc;
@@ -196,6 +196,8 @@ async fn add_action_smoke_test() -> Result<(), Error> {
         new_awaited_action
     };
 
+    let worker_operation_id = OperationId::from(WORKER_OPERATION_ID);
+
     let ft_aggregate_args = vec![
         format!("aa__unique_qualifier__{SCRIPT_VERSION}").into(),
         format!("@unique_qualifier:{{ {INSTANCE_NAME}_SHA256_0000000000000000000000000000000000000000000000000000000000000000_0_c }}").into(),
@@ -351,6 +353,43 @@ async fn add_action_smoke_test() -> Result<(), Error> {
         )
         .expect(
             MockCommand {
+                cmd: Str::from_static("HMGET"),
+                subcommand: None,
+                args: vec![
+                    format!("cid_{CLIENT_OPERATION_ID}").as_bytes().into(),
+                    "version".as_bytes().into(),
+                    "data".as_bytes().into(),
+                ],
+            },
+            Ok(RedisValue::Array(vec![
+                // Version.
+                RedisValue::Null,
+                // Data.
+                RedisValue::Bytes(Bytes::from(serde_json::to_string(&worker_operation_id).unwrap())),
+            ])),
+            None,
+        )
+        .expect(
+            MockCommand {
+                cmd: Str::from_static("HMGET"),
+                subcommand: None,
+                args: vec![
+                    format!("aa_{WORKER_OPERATION_ID}").as_bytes().into(),
+                    "version".as_bytes().into(),
+                    "data".as_bytes().into(),
+                ],
+            },
+            Ok(RedisValue::Array(vec![
+                // Version.
+                "2".into(),
+                // Data.
+                RedisValue::Bytes(Bytes::from(serde_json::to_string(&new_awaited_action).unwrap())),
+            ])),
+            None,
+        )
+
+        .expect(
+            MockCommand {
                 cmd: Str::from_static("EVALSHA"),
                 subcommand: None,
                 args: vec![
@@ -451,6 +490,18 @@ async fn add_action_smoke_test() -> Result<(), Error> {
             changed_awaited_action_res.unwrap().state().stage,
             ActionStage::Queued
         );
+    }
+
+    {
+        let get_subscription = awaited_action_db
+            .get_awaited_action_by_id(&OperationId::from(CLIENT_OPERATION_ID))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let get_res = get_subscription.borrow().await;
+
+        assert_eq!(get_res.unwrap().state().stage, ActionStage::Executing);
     }
 
     {


### PR DESCRIPTION
# Description

Redis Scheduler Store serialised OperationId as a JSON, but deserialised it as String, which resulted in (Error 34 Not Found) when running Bazel build with RBE.

Fixes #1855

## Type of change

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've observed the issue when running nativelink 0.6.0 (and snapshot versions) deployed in Kubernetes cluster by subscribing to the key misses on Redis instance used as a scheduler store.
```
redis-cli -c -u redis://localhost:6379 config set notify-keyspace-events KEm
redis-cli --csv psubscribe '__key*__:aa*'
"psubscribe","__key*__:aa*",1
"pmessage","__key*__:aa*","__keyspace@0__:aa_{\"Uuid\":\"9ad3639a-879f-4cc0-89c7-69186c13e6a0\"}","keymiss"
"pmessage","__key*__:aa*","__keyspace@0__:aa_{\"Uuid\":\"738f1da4-f311-4273-a3f7-60c294249df9\"}","keymiss"
"pmessage","__key*__:aa*","__keyspace@0__:aa_{\"Uuid\":\"147a9c57-c0a2-46c9-ab7d-bd0a96d45c65\"}","keymiss"
```
And I've reproduced the issue by adding `get_awaited_action_by_id` call in `add_action_smoke_test`.

## Checklist

- [ ] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/nativelink/1856)
<!-- Reviewable:end -->
